### PR TITLE
Bug when paths don't contain spaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+elm-stuff/

--- a/src/ParserPrimitives.elm
+++ b/src/ParserPrimitives.elm
@@ -127,15 +127,14 @@ applyExponent float (Exponent exp) =
 floatingPointConstant : Parser Float
 floatingPointConstant =
     join <|
-        inContext "floatingPointConstant" <|
-            oneOf
-                [ succeed applyExponent
-                    |= fractionalConstant
-                    |= withDefault (Exponent 0) exponent
-                , succeed applyExponent
-                    |= Parser.map toFloat digitSequence
-                    |= exponent
-                ]
+        oneOf
+            [ succeed applyExponent
+                |= fractionalConstant
+                |= withDefault (Exponent 0) exponent
+            , succeed applyExponent
+                |= Parser.map toFloat digitSequence
+                |= exponent
+            ]
 
 
 integerConstant : Parser Int

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -70,36 +70,44 @@ pathTests =
 suite : Test
 suite =
     describe "svg path syntax parser in elm" <|
+        let
+            serious =
+                "M600,350 l10,10 l20,20 Z"
+        in
+            [ test "moveto drawto command group" <|
+                \_ ->
+                    Parser.run moveToDrawToCommandGroup serious
+                        |> Expect.equal (Ok { moveto = MoveTo Absolute ( 600, 350 ), drawtos = [ LineTo Relative [ ( 10, 10 ) ], LineTo Relative [ ( 20, 20 ) ], ClosePath ] })
+            , test "moveto drawto command groups" <|
+                \_ ->
+                    Parser.run moveToDrawToCommandGroups serious
+                        |> Expect.equal (Ok [ { moveto = MoveTo Absolute ( 600, 350 ), drawtos = [ LineTo Relative [ ( 10, 10 ) ], LineTo Relative [ ( 20, 20 ) ], ClosePath ] } ])
+            , test "relative moveto 0,0" <|
+                \_ ->
+                    Parser.run moveto "m 0,0"
+                        |> Expect.equal (Ok ( MoveTo Relative ( 0, 0 ), Nothing ))
+            , test "lineto argument sequence" <|
+                \_ ->
+                    Parser.run linetoArgumentSequence "10,10 20,20"
+                        |> Expect.equal
+                            (Ok [ ( 10, 10 ), ( 20, 20 ) ])
+            , test "lineto command with multiple arguments " <|
+                \_ ->
+                    Parser.run lineto "l 10,10 20,20"
+                        |> Expect.equal
+                            (Ok (LineTo Relative [ ( 10, 10 ), ( 20, 20 ) ]))
+            ]
+
+
+whitespaceParsing : Test
+whitespaceParsing =
+    describe "svg path parsing uses whitespce permisively" <|
         List.map
             (\( label, serious ) ->
-                describe label
-                    [ test "moveto drawto command group" <|
-                        \_ ->
-                            Parser.run moveToDrawToCommandGroup serious
-                                |> Expect.equal (Ok { moveto = MoveTo Absolute ( 600, 350 ), drawtos = [ LineTo Relative [ ( 10, 10 ) ], LineTo Relative [ ( 20, 20 ) ], ClosePath ] })
-                    , test "moveto drawto command groups" <|
-                        \_ ->
-                            Parser.run moveToDrawToCommandGroups serious
-                                |> Expect.equal (Ok [ { moveto = MoveTo Absolute ( 600, 350 ), drawtos = [ LineTo Relative [ ( 10, 10 ) ], LineTo Relative [ ( 20, 20 ) ], ClosePath ] } ])
-                    , test "svgPath" <|
-                        \_ ->
-                            Parser.run svgMixedPath serious
-                                |> Expect.equal (Ok [ { moveto = MoveTo Absolute ( 600, 350 ), drawtos = [ LineTo Relative [ ( 10, 10 ) ], LineTo Relative [ ( 20, 20 ) ], ClosePath ] } ])
-                    , test "relative moveto 0,0" <|
-                        \_ ->
-                            Parser.run moveto "m 0,0"
-                                |> Expect.equal (Ok ( MoveTo Relative ( 0, 0 ), Nothing ))
-                    , test "lineto argument sequence" <|
-                        \_ ->
-                            Parser.run linetoArgumentSequence "10,10 20,20"
-                                |> Expect.equal
-                                    (Ok [ ( 10, 10 ), ( 20, 20 ) ])
-                    , test "lineto command with multiple arguments " <|
-                        \_ ->
-                            Parser.run lineto "l 10,10 20,20"
-                                |> Expect.equal
-                                    (Ok (LineTo Relative [ ( 10, 10 ), ( 20, 20 ) ]))
-                    ]
+                test label <|
+                    \_ ->
+                        Parser.run svgMixedPath serious
+                            |> Expect.equal (Ok [ { moveto = MoveTo Absolute ( 600, 350 ), drawtos = [ LineTo Relative [ ( 10, 10 ) ], LineTo Relative [ ( 20, 20 ) ], ClosePath ] } ])
             )
             [ ( "no spacing", "M600,350l10,10l20,20Z" )
             , ( "some spaces", "M600,350 l10,10 l20,20 Z" )

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -69,38 +69,42 @@ pathTests =
 
 suite : Test
 suite =
-    let
-        serious =
-            """M600,350 l10,10 l20,20 Z
-            """
-    in
-        describe "svg path syntax parser in elm"
-            [ test "moveto drawto command group" <|
-                \_ ->
-                    Parser.run moveToDrawToCommandGroup serious
-                        |> Expect.equal (Ok { moveto = MoveTo Absolute ( 600, 350 ), drawtos = [ LineTo Relative [ ( 10, 10 ) ], LineTo Relative [ ( 20, 20 ) ], ClosePath ] })
-            , test "moveto drawto command groups" <|
-                \_ ->
-                    Parser.run moveToDrawToCommandGroups serious
-                        |> Expect.equal (Ok [ { moveto = MoveTo Absolute ( 600, 350 ), drawtos = [ LineTo Relative [ ( 10, 10 ) ], LineTo Relative [ ( 20, 20 ) ], ClosePath ] } ])
-            , test "svgPath" <|
-                \_ ->
-                    Parser.run svgMixedPath serious
-                        |> Expect.equal (Ok [ { moveto = MoveTo Absolute ( 600, 350 ), drawtos = [ LineTo Relative [ ( 10, 10 ) ], LineTo Relative [ ( 20, 20 ) ], ClosePath ] } ])
-            , test "relative moveto 0,0" <|
-                \_ ->
-                    Parser.run moveto "m 0,0"
-                        |> Expect.equal (Ok ( MoveTo Relative ( 0, 0 ), Nothing ))
-            , test "lineto argument sequence" <|
-                \_ ->
-                    Parser.run linetoArgumentSequence "10,10 20,20"
-                        |> Expect.equal
-                            (Ok [ ( 10, 10 ), ( 20, 20 ) ])
-            , test "lineto command with multiple arguments " <|
-                \_ ->
-                    Parser.run lineto "l 10,10 20,20"
-                        |> Expect.equal
-                            (Ok (LineTo Relative [ ( 10, 10 ), ( 20, 20 ) ]))
+    describe "svg path syntax parser in elm" <|
+        List.map
+            (\( label, serious ) ->
+                describe label
+                    [ test "moveto drawto command group" <|
+                        \_ ->
+                            Parser.run moveToDrawToCommandGroup serious
+                                |> Expect.equal (Ok { moveto = MoveTo Absolute ( 600, 350 ), drawtos = [ LineTo Relative [ ( 10, 10 ) ], LineTo Relative [ ( 20, 20 ) ], ClosePath ] })
+                    , test "moveto drawto command groups" <|
+                        \_ ->
+                            Parser.run moveToDrawToCommandGroups serious
+                                |> Expect.equal (Ok [ { moveto = MoveTo Absolute ( 600, 350 ), drawtos = [ LineTo Relative [ ( 10, 10 ) ], LineTo Relative [ ( 20, 20 ) ], ClosePath ] } ])
+                    , test "svgPath" <|
+                        \_ ->
+                            Parser.run svgMixedPath serious
+                                |> Expect.equal (Ok [ { moveto = MoveTo Absolute ( 600, 350 ), drawtos = [ LineTo Relative [ ( 10, 10 ) ], LineTo Relative [ ( 20, 20 ) ], ClosePath ] } ])
+                    , test "relative moveto 0,0" <|
+                        \_ ->
+                            Parser.run moveto "m 0,0"
+                                |> Expect.equal (Ok ( MoveTo Relative ( 0, 0 ), Nothing ))
+                    , test "lineto argument sequence" <|
+                        \_ ->
+                            Parser.run linetoArgumentSequence "10,10 20,20"
+                                |> Expect.equal
+                                    (Ok [ ( 10, 10 ), ( 20, 20 ) ])
+                    , test "lineto command with multiple arguments " <|
+                        \_ ->
+                            Parser.run lineto "l 10,10 20,20"
+                                |> Expect.equal
+                                    (Ok (LineTo Relative [ ( 10, 10 ), ( 20, 20 ) ]))
+                    ]
+            )
+            [ ( "no spacing", "M600,350l10,10l20,20Z" )
+            , ( "some spaces", "M600,350 l10,10 l20,20 Z" )
+            , ( "well spaced", "M 600, 350 l 10, 10 l 20, 20 Z" )
+            , ( "crazy spaced", "M   600  ,  350 l  10  , 10 l 20  , 20  Z" )
             ]
 
 


### PR DESCRIPTION
The test case exposes the bug, as it fails with

```
↓ Tests
↓ svg path syntax parser in elm
↓ no spacing
✗ svgPath

    Err { row = 1, col = 9, source = "M600,350l10,10l20,20Z", problem = BadInt, context = [{ row = 1, col = 6, description = "number" },{ row = 1, col = 2, description = "coordinate pair" },{ row = 1, col = 1, description = "moveto" },{ row = 1, col = 1, description = "moveto drawto command group" }] }
    ╷
    │ Expect.equal
    ╵
    Ok ([{ moveto = MoveTo Absolute (600,350), drawtos = [LineTo Relative [(10,10)],LineTo Relative [(20,20)],ClosePath] }])
```

However, I'm not sure how to actually fix it. I'll continue digging through the source, but would appreciate some pointers.