### PR TITLE
Namespace package

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The code for drawing the letter H looks like this:
 
 ```elm
 import SubPath exposing SubPath
-import Curve
+import Svg.Curve as Curve
 import Svg exposing (Svg)
 import Svg.Attributes exposing 
     (width, height, viewBox, fill, stroke)
@@ -71,8 +71,8 @@ A `SubPath` can be `ArcLengthParameterized`, to sample the curve, animate along 
 Finally, a piece of svg path syntax can be parsed into a list of `SubPath`s
 
 ```elm
-import Path 
-import SubPath
+import SvgPath 
+import Svg.SubPath as SubPath
 
 pathAsString = 
     """
@@ -87,7 +87,7 @@ pathAsString =
     """
 
 path = 
-    Path.parse pathAsString
+    SvgPath.parse pathAsString
         |> Result.toMaybe
         |> Maybe.andThen List.head
 ```
@@ -103,7 +103,7 @@ access the `OpenSolid` values and use that package to modify your geometry.
 
 ## Others 
 
-The `Path` module is a convenience for when you have a list of `SubPath`s and want to render them into one `path` element.
+The `SvgPath` module is a convenience for when you have a list of `SubPath`s and want to render them into one `path` element.
 
 The `LowLevel.Command` module is meant for package authors. It allows more control over the generated svg instructions, but 
 is pretty cumbersome to work with. Try to stay away from it.

--- a/examples/CurveImages.elm
+++ b/examples/CurveImages.elm
@@ -11,10 +11,10 @@ and then used in the documentations
 -}
 
 import Color
-import Curve
+import Svg.Curve as Curve
 import Html
 import Html.Attributes
-import Path
+import SvgPath
 import SubPath exposing (SubPath, with)
 import Svg exposing (Attribute, Svg)
 import Svg.Attributes exposing (..)

--- a/examples/EvenlySpaced.elm
+++ b/examples/EvenlySpaced.elm
@@ -6,10 +6,10 @@ import Html.Attributes as Attributes
 import Html.Events as Events
 import Svg.Attributes exposing (width, height, fill, stroke)
 import Html.Attributes
-import CurveImages exposing (gridRect, svgGrid, nodes)
-import Curve
-import SubPath
-import Path
+import Svg.Curve as CurveImages exposing (gridRect, svgGrid, nodes)
+import Svg.Curve as Curve
+import Svg.SubPath as SubPath
+import SvgPath
 import Geometry.Ellipse exposing (signedAngle)
 import AnimationFrame
 import Time exposing (Time)

--- a/examples/InterpolationDocumentation.elm
+++ b/examples/InterpolationDocumentation.elm
@@ -6,8 +6,8 @@ import Html exposing (..)
 import Html.Attributes
 import LowLevel.Command exposing (moveTo, lineTo, closePath)
 import SubPath exposing (subpath)
-import Path
-import Curve exposing (..)
+import SvgPath
+import Svg.Curve as Curve exposing (..)
 import Color
 import Color.Interpolate as Color exposing (Space(LAB))
 import Color.Convert as Color

--- a/examples/LabelPositions.elm
+++ b/examples/LabelPositions.elm
@@ -1,6 +1,6 @@
 module Main exposing (main)
 
-import Curve
+import Svg.Curve as Curve
 import Html.Attributes exposing (attribute)
 import LowLevel.Command exposing (..)
 import OpenSolid.Direction2d as Direction2d

--- a/src/Svg/Curve.elm
+++ b/src/Svg/Curve.elm
@@ -1,4 +1,4 @@
-module Curve exposing
+module Svg.Curve exposing
     ( linear, linearClosed
     , cubicBezier, smoothCubicBezier, quadraticBezier, smoothQuadraticBezier
     , step, stepBefore, stepAfter
@@ -98,7 +98,7 @@ import List.Extra as List
 import LowLevel.Command as Command exposing (..)
 import Path.LowLevel as LowLevel exposing (Mode(..))
 import Quantity exposing (Unitless)
-import SubPath exposing (SubPath(..), close, connect, empty)
+import Svg.SubPath exposing (SubPath(..), close, connect, empty)
 import Vector2d exposing (Vector2d)
 
 
@@ -149,7 +149,7 @@ linear points =
             empty
 
         x :: xs ->
-            SubPath.with (moveTo x) [ lineTo xs ]
+            Svg.SubPath.with (moveTo x) [ lineTo xs ]
 
 
 {-| Draw a straigt line between the data points, connecting the ends.
@@ -164,7 +164,7 @@ linearClosed points =
             empty
 
         x :: xs ->
-            SubPath.with (moveTo x) [ lineTo xs, closePath ]
+            Svg.SubPath.with (moveTo x) [ lineTo xs, closePath ]
 
 
 {-| Shorthand to draw a sequence of cubic bezier segments
@@ -176,7 +176,7 @@ cubicBezier start points =
             empty
 
         x :: xs ->
-            SubPath.with (moveTo start) [ cubicCurveTo points ]
+            Svg.SubPath.with (moveTo start) [ cubicCurveTo points ]
 
 
 {-| Shorthand to draw a sequence of smooth cubic bezier segments
@@ -193,7 +193,7 @@ smoothCubicBezier start first points =
         lowLevelSubPath =
             { moveto = LowLevel.MoveTo Absolute start, drawtos = lowLevelDrawTos }
     in
-    SubPath.fromLowLevel lowLevelSubPath
+    Svg.SubPath.fromLowLevel lowLevelSubPath
 
 
 {-| Shorthand to draw a sequence of quadratic bezier segments
@@ -205,7 +205,7 @@ quadraticBezier start points =
             empty
 
         x :: xs ->
-            SubPath.with (moveTo start) [ quadraticCurveTo points ]
+            Svg.SubPath.with (moveTo start) [ quadraticCurveTo points ]
 
 
 {-| Shorthand to draw a sequence of smooth quadratic bezier segments
@@ -222,7 +222,7 @@ smoothQuadraticBezier start first points =
         lowLevelSubPath =
             { moveto = LowLevel.MoveTo Absolute start, drawtos = lowLevelDrawTos }
     in
-    SubPath.fromLowLevel lowLevelSubPath
+    Svg.SubPath.fromLowLevel lowLevelSubPath
 
 
 {-| Convert `(angle, radius)` pairs to `(x, y)` coordinates, relative to the given vector.
@@ -309,10 +309,10 @@ basis points =
     in
     case points of
         p0 :: p1 :: _ :: _ ->
-            SubPath.with (moveTo p0) (lineTo [ toFirst (Vector2d.fromTuple Quantity.float p0) (Vector2d.fromTuple Quantity.float p1) ] :: commonCase [] points)
+            Svg.SubPath.with (moveTo p0) (lineTo [ toFirst (Vector2d.fromTuple Quantity.float p0) (Vector2d.fromTuple Quantity.float p1) ] :: commonCase [] points)
 
         [ p0, p1 ] ->
-            SubPath.with (moveTo p0) [ lineTo [ p1 ] ]
+            Svg.SubPath.with (moveTo p0) [ lineTo [ p1 ] ]
 
         _ ->
             empty
@@ -358,7 +358,7 @@ basisClosed points =
                         |> Vector2d.scaleBy (1 / 6)
                         |> Vector2d.toTuple Quantity.toFloat
             in
-            SubPath.with (moveTo start)
+            Svg.SubPath.with (moveTo start)
                 [ cubicCurveTo (commonCase [] closing (p3 :: p4 :: rest)) ]
 
         [ p0_, p1_ ] ->
@@ -377,7 +377,7 @@ basisClosed points =
                     Vector2d.scaleBy (1 / 3) (Vector2d.plus p1 (Vector2d.scaleBy 2 p0))
                         |> Vector2d.toTuple Quantity.toFloat
             in
-            SubPath.with (moveTo start) [ lineTo [ end ], closePath ]
+            Svg.SubPath.with (moveTo start) [ lineTo [ end ], closePath ]
 
         _ ->
             empty
@@ -407,7 +407,7 @@ basisOpen points =
                         |> Vector2d.scaleBy (1 / 6)
                         |> Vector2d.toTuple Quantity.toFloat
             in
-            SubPath.with (moveTo start) [ cubicCurveTo (helper [] (p1 :: p :: pp :: rest)) ]
+            Svg.SubPath.with (moveTo start) [ cubicCurveTo (helper [] (p1 :: p :: pp :: rest)) ]
 
         _ ->
             empty
@@ -505,10 +505,10 @@ cardinal tension points =
     in
     case points of
         [ p0, p1 ] ->
-            SubPath.with (moveTo p0) [ lineTo [ p1 ] ]
+            Svg.SubPath.with (moveTo p0) [ lineTo [ p1 ] ]
 
         p0 :: p1 :: p2 :: rest ->
-            SubPath.with (moveTo p0) [ cubicCurveTo (cardinalPoint k p1 p0 p1 p2 :: helper [] points) ]
+            Svg.SubPath.with (moveTo p0) [ cubicCurveTo (cardinalPoint k p1 p0 p1 p2 :: helper [] points) ]
 
         _ ->
             empty
@@ -527,7 +527,7 @@ cardinalOpen tension points =
             List.map4 (cardinalPoint k) (p0 :: p1 :: p2 :: p3 :: rest) (p1 :: p2 :: p3 :: rest) (p2 :: p3 :: rest) (p3 :: rest)
                 |> cubicCurveTo
                 |> List.singleton
-                |> SubPath.with (moveTo p1)
+                |> Svg.SubPath.with (moveTo p1)
 
         _ ->
             empty
@@ -560,7 +560,7 @@ cardinalClosed tension points =
             empty
 
         [ p0, p1 ] ->
-            SubPath.with (moveTo p1) [ lineTo [ p0 ], closePath ]
+            Svg.SubPath.with (moveTo p1) [ lineTo [ p0 ], closePath ]
 
         p3 :: p4 :: p5 :: rest ->
             let
@@ -570,7 +570,7 @@ cardinalClosed tension points =
                     , cardinalPoint k p2 p3 p4 p5
                     ]
             in
-            SubPath.with (moveTo p4) [ cubicCurveTo (helper [] end points) ]
+            Svg.SubPath.with (moveTo p4) [ cubicCurveTo (helper [] end points) ]
 
 
 catmullRomDistance : Float -> Vector2d Unitless coordinates -> Vector2d Unitless coordinates -> ( Float, Float )
@@ -595,14 +595,14 @@ catmullRom alpha points =
     else
         case points of
             [ p1, p2 ] ->
-                SubPath.with (moveTo p1) [ lineTo [ p2 ] ]
+                Svg.SubPath.with (moveTo p1) [ lineTo [ p2 ] ]
 
             p0 :: p1 :: p2 :: rest ->
                 let
                     ending q0 q1 q2 =
                         [ catmullRomPoint alpha q0 q1 q2 q2 ]
                 in
-                SubPath.with (moveTo p0) [ cubicCurveTo (catmullRomHelper alpha ending (p0 :: points) []) ]
+                Svg.SubPath.with (moveTo p0) [ cubicCurveTo (catmullRomHelper alpha ending (p0 :: points) []) ]
 
             _ ->
                 empty
@@ -636,14 +636,14 @@ catmullRomOpen alpha points =
     else
         case points of
             [ p0, p1, p2 ] ->
-                SubPath.with (moveTo p1) [ closePath ]
+                Svg.SubPath.with (moveTo p1) [ closePath ]
 
             p0 :: p1 :: p2 :: p :: rest ->
                 let
                     ending _ _ _ =
                         []
                 in
-                SubPath.with (moveTo p1) [ cubicCurveTo (catmullRomHelper alpha ending points []) ]
+                Svg.SubPath.with (moveTo p1) [ cubicCurveTo (catmullRomHelper alpha ending points []) ]
 
             _ ->
                 empty
@@ -665,7 +665,7 @@ catmullRomClosed alpha points =
                 empty
 
             [ p1, p2 ] ->
-                SubPath.with (moveTo p2) [ lineTo [ p1 ], closePath ]
+                Svg.SubPath.with (moveTo p2) [ lineTo [ p1 ], closePath ]
 
             p3 :: p4 :: p5 :: rest ->
                 let
@@ -675,7 +675,7 @@ catmullRomClosed alpha points =
                         , catmullRomPoint alpha p2 p3 p4 p5
                         ]
                 in
-                SubPath.with (moveTo p4) [ cubicCurveTo (catmullRomHelper alpha ending points []) ]
+                Svg.SubPath.with (moveTo p4) [ cubicCurveTo (catmullRomHelper alpha ending points []) ]
 
 
 catmullRomPoint : Float -> ( Float, Float ) -> ( Float, Float ) -> ( Float, Float ) -> ( Float, Float ) -> Triplet ( Float, Float )
@@ -838,10 +838,10 @@ monotoneX points =
                 otherInstructions =
                     monotoneXHelper [] t1 (p1 :: p :: rest)
             in
-            SubPath.with (moveTo p0) [ cubicCurveTo (initialInstruction :: otherInstructions) ]
+            Svg.SubPath.with (moveTo p0) [ cubicCurveTo (initialInstruction :: otherInstructions) ]
 
         [ p0, p1 ] ->
-            SubPath.with (moveTo p0) [ lineTo [ p1 ] ]
+            Svg.SubPath.with (moveTo p0) [ lineTo [ p1 ] ]
 
         _ ->
             empty
@@ -883,7 +883,7 @@ monotoneY points =
     points
         |> List.map (\( x, y ) -> ( y, x ))
         |> monotoneX
-        |> SubPath.mapCoordinate (\( x, y ) -> ( y, x ))
+        |> Svg.SubPath.mapCoordinate (\( x, y ) -> ( y, x ))
 
 
 toH : Float -> Float -> Float
@@ -911,7 +911,7 @@ natural points =
             empty
 
         [ p1, p2 ] ->
-            SubPath.with (moveTo p1) [ lineTo [ p2 ] ]
+            Svg.SubPath.with (moveTo p1) [ lineTo [ p2 ] ]
 
         p :: _ :: _ ->
             let
@@ -921,7 +921,7 @@ natural points =
                         |> naturalControlPoints
                         |> List.map (mapTriplet (Vector2d.toTuple Quantity.toFloat))
             in
-            SubPath.with (moveTo p) [ cubicCurveTo cubicTriplets ]
+            Svg.SubPath.with (moveTo p) [ cubicCurveTo cubicTriplets ]
 
 
 {-| ![step](https://rawgit.com/folkertdev/one-true-path-experiment/master/docs/step.svg)

--- a/src/Svg/Path.elm
+++ b/src/Svg/Path.elm
@@ -1,8 +1,8 @@
-module Path exposing
-    ( Path
-    , parse
+module Svg.Path exposing
+    ( parse
     , element, toString
     , fromLowLevel, toLowLevel
+    , SvgPath
     )
 
 {-| Module for layering SubPaths into Paths.
@@ -36,27 +36,27 @@ import LowLevel.Command as Command
 import Parser.Advanced
 import Path.LowLevel as LowLevel
 import Path.LowLevel.Parser as PathParser
-import SubPath exposing (SubPath)
 import Svg
 import Svg.Attributes
+import Svg.SubPath exposing (SubPath)
 
 
 {-| A path is a list of [`SubPath`](#subpath)s.
 -}
-type alias Path =
+type alias SvgPath =
     List SubPath
 
 
 {-| Construct an svg path element from a `Path` with the given attributes
 -}
-element : Path -> List (Svg.Attribute msg) -> Svg.Svg msg
+element : SvgPath -> List (Svg.Attribute msg) -> Svg.Svg msg
 element path attributes =
     Svg.path (Svg.Attributes.d (toString path) :: attributes) []
 
 
 {-| Turn a `Path` into a `String`. The result is ready to be used with the `d` attribute.
 
-    import Curve
+    import Svg.Curve as Curve
     import SubPath exposing (SubPath)
 
     myPath : SubPath
@@ -76,14 +76,14 @@ element path attributes =
         --> Ok arc
 
 -}
-toString : Path -> String
+toString : SvgPath -> String
 toString =
-    String.join " " << List.map SubPath.toString
+    String.join " " << List.map Svg.SubPath.toString
 
 
 {-| Parse a path string into a `Path`
 
-    import Curve
+    import Svg.Curve as Curve
     import SubPath exposing (SubPath)
 
     expected : SubPath
@@ -99,14 +99,14 @@ The parser uses [`elm-tools/parser`](http://package.elm-lang.org/packages/elm-to
 The error type is [`Parser.Error`](http://package.elm-lang.org/packages/elm-tools/parser/2.0.1/Parser#Error).
 
 -}
-parse : String -> Result (List (Parser.Advanced.DeadEnd String String)) Path
+parse : String -> Result (List (Parser.Advanced.DeadEnd String String)) SvgPath
 parse =
     Result.map fromLowLevel << PathParser.parse
 
 
 {-| Converting a svg-path-lowlevel subpath into a one-true-path subpath. Used in parsing
 -}
-fromLowLevel : List LowLevel.SubPath -> Path
+fromLowLevel : List LowLevel.SubPath -> SvgPath
 fromLowLevel lowlevels =
     case lowlevels of
         [] ->
@@ -128,7 +128,7 @@ fromLowLevel lowlevels =
                                 ( stateAfterDrawtos, newDrawTos ) =
                                     Command.fromLowLevelDrawTos drawtos stateAfterMoveTo
                             in
-                            ( stateAfterDrawtos, SubPath.with newMoveTo newDrawTos :: accum )
+                            ( stateAfterDrawtos, Svg.SubPath.with newMoveTo newDrawTos :: accum )
                     in
                     List.foldl folder ( initialCursorState, [] ) lowlevels
                         |> Tuple.second
@@ -137,6 +137,6 @@ fromLowLevel lowlevels =
 
 {-| Convert a path to a svg-path-lowlevel list of subpaths
 -}
-toLowLevel : Path -> List LowLevel.SubPath
+toLowLevel : SvgPath -> List LowLevel.SubPath
 toLowLevel =
-    List.filterMap SubPath.toLowLevel
+    List.filterMap Svg.SubPath.toLowLevel

--- a/src/Svg/Segment.elm
+++ b/src/Svg/Segment.elm
@@ -1,4 +1,4 @@
-module Segment exposing
+module Svg.Segment exposing
     ( Segment(..)
     , line, quadratic, cubic, ellipticalArc
     , at, angle

--- a/src/Svg/SubPath.elm
+++ b/src/Svg/SubPath.elm
@@ -1,4 +1,4 @@
-module SubPath exposing
+module Svg.SubPath exposing
     ( SubPath
     , with, empty
     , element, toString, toStringWith
@@ -18,10 +18,10 @@ module SubPath exposing
 t
 In most cases it should be created with functions from the `Curve` module.
 
-    import Curve
     import SubPath exposing (connect)
     import Svg
     import Svg.Attributes exposing (fill)
+    import Svg.Curve as Curve
 
     right =
         Curve.linear [ ( 0, 0 ), ( 1, 0 ) ]
@@ -73,7 +73,7 @@ And can generate svg elements
 
 ![composition of subpaths](https://rawgit.com/folkertdev/one-true-path-experiment/master/docs/subpath-composition.svg)
 
-    import Curve
+    import Svg.Curve as Curve
 
     curve : SubPath
     curve =
@@ -139,9 +139,9 @@ import LowLevel.Command as Command exposing (CursorState, DrawTo(..), MoveTo(..)
 import Path.LowLevel as LowLevel
 import Point2d exposing (Point2d)
 import Quantity
-import Segment exposing (Segment)
 import Svg
 import Svg.Attributes
+import Svg.Segment as Segment exposing (Segment)
 import Vector2d exposing (Vector2d)
 
 
@@ -233,7 +233,7 @@ optionFolder option config =
 
 {-| Set the maximum number of decimal places in the output
 
-    import Curve
+    import Svg.Curve as Curve
 
     line : SubPath
     line = Curve.linear [ (0, 0), (1/3, 1/7) ]
@@ -254,7 +254,7 @@ decimalPlaces =
 This can save a few characters, but more importantly makes
 comparison of subpaths (based on the ouput string) more reliable.
 
-    import Curve
+    import Svg.Curve as Curve
 
     right : SubPath
     right = Curve.linear [ (0, 0), (1, 0) ]
@@ -281,7 +281,7 @@ mergeAdjacent =
 
 {-| Convert a subpath into SVG path notation
 
-    import Curve
+    import Svg.Curve as Curve
 
     line : SubPath
     line = Curve.linear [ (0,0), (10,10), (10, 20) ]
@@ -483,8 +483,8 @@ finalCursorState { moveto, drawtos } =
 In the conversion, the starting point of a segment is discarded:
 It is assumed that for every two adjacent segments in the list, the first segment's end point is the second segment's starting point
 
-    import Curve
-    import Segment exposing (line)
+    import Svg.Curve as Curve
+    import Svg.Segment as Segment exposing (line)
 
 
     [ line (0,0) (10,10) , line (10, 10) (20, 10) ]
@@ -505,8 +505,8 @@ fromSegments segments =
 
 {-| Convert a subpath to its `Segment`s
 
-    import Curve
-    import Segment exposing (line)
+    import Svg.Curve as Curve
+    import Svg.Segment as Segment exposing (line)
 
     Curve.linear [ (0,0), (10,10), (20, 10) ]
         |> toSegments
@@ -800,7 +800,7 @@ arcLengthParameterizedHelper tolerance segments =
 
 {-| Find the total arc length of an elliptical arc. This will be accurate to within the tolerance given when calling arcLengthParameterized.
 
-    import Curve
+    import Svg.Curve as Curve
 
     Curve.linear [ (0,0), (100, 0) ]
         |> arcLengthParameterized 1e-4
@@ -901,7 +901,7 @@ traverse tagger parameterized t =
 
 {-| A point at some distance along the curve.
 
-    import Curve
+    import Svg.Curve as Curve
 
     parameterized : ArcLengthParameterized
     parameterized =
@@ -919,7 +919,7 @@ pointAlong parameterized t =
 
 {-| The tangent along the curve
 
-    import Curve
+    import Svg.Curve as Curve
 
     parameterized : ArcLengthParameterized
     parameterized =
@@ -952,7 +952,7 @@ arcLengthToParameterValue parameterized t =
 {-| Find `n` evenly spaced points on an arc length parameterized subpath
 Includes the start and end point.
 
-    import Curve
+    import Svg.Curve as Curve
 
     curve : ArcLengthParameterized
     curve =

--- a/tests/CurveTest.elm
+++ b/tests/CurveTest.elm
@@ -57,11 +57,11 @@ console.log("4 points", result)
 
 -}
 
-import Curve exposing (..)
 import Expect
 import LowLevel.Command exposing (DrawTo(..), MoveTo(..))
-import Path
-import SubPath exposing (SubPath, decimalPlaces, mergeAdjacent)
+import Svg.Curve as Curve exposing (..)
+import Svg.Path as Path
+import Svg.SubPath as SubPath exposing (SubPath, decimalPlaces, mergeAdjacent)
 import Test exposing (..)
 
 

--- a/tests/Issue7.elm
+++ b/tests/Issue7.elm
@@ -1,9 +1,9 @@
 module Issue7 exposing (suite)
 
 import Expect exposing (FloatingPointTolerance(..))
-import Path
-import Segment
-import SubPath
+import Svg.Path as Path
+import Svg.Segment as Segment
+import Svg.SubPath as SubPath
 import Test exposing (..)
 
 

--- a/tests/NaturalTest.elm
+++ b/tests/NaturalTest.elm
@@ -5,9 +5,9 @@ import Fuzz exposing (..)
 import Internal.NaturalInterpolation exposing (naturalControlPoints)
 import List.Extra as List
 import LowLevel.Command exposing (cubicCurveTo, lineTo, moveTo)
-import Path exposing (Path)
 import Quantity
-import SubPath
+import Svg.Path as Path exposing (SvgPath)
+import Svg.SubPath as SubPath
 import Test exposing (..)
 import Vector2d
 
@@ -161,7 +161,7 @@ controlPoints points =
     ( a_, b_ )
 
 
-natural : List ( Float, Float ) -> Path
+natural : List ( Float, Float ) -> SvgPath
 natural points =
     case points of
         [] ->

--- a/tests/PathTest.elm
+++ b/tests/PathTest.elm
@@ -3,9 +3,9 @@ module PathTest exposing (docsExample, fuzzCoordinate, fuzzMode, fuzzMoveTo, toA
 import Expect
 import Fuzz exposing (..)
 import LowLevel.Command as Command exposing (DrawTo(..), MoveTo(..))
-import Path
 import Path.LowLevel as LowLevel exposing (ArcFlag(..), Direction(..), Mode(..))
-import SubPath
+import Svg.Path as Path
+import Svg.SubPath as SubPath
 import Test exposing (..)
 
 

--- a/tests/SegmentTest.elm
+++ b/tests/SegmentTest.elm
@@ -1,7 +1,6 @@
 module SegmentTest exposing (angle, arc, cleanFloat, cleanVec2, conversionFromToDrawTo, derivative, segment, segments, startAndEnd, toSegments, vec2)
 
 import Angle
-import Curve
 import Direction2d
 import EllipticalArc2d exposing (EllipticalArc2d)
 import Expect
@@ -10,8 +9,9 @@ import Geometry.Ellipse as Ellipse
 import LowLevel.Command exposing (arcTo, clockwise, counterClockwise, largestArc, lineTo, moveTo, smallestArc)
 import Point2d exposing (Point2d)
 import Quantity
-import Segment exposing (Segment(..))
-import SubPath
+import Svg.Curve as Curve
+import Svg.Segment as Segment exposing (Segment(..))
+import Svg.SubPath as SubPath
 import Test exposing (..)
 import Vector2d exposing (Vector2d)
 

--- a/tests/SubPathTest.elm
+++ b/tests/SubPathTest.elm
@@ -1,12 +1,12 @@
 module SubPathTest exposing (arcLengthParameterization, down, left, n, right, slope, tests, u, up)
 
-import Curve
 import Expect
 import Fuzz
 import LowLevel.Command exposing (lineTo, moveTo, quadraticCurveTo)
 import Quantity
-import Segment exposing (Segment(..))
-import SubPath
+import Svg.Curve as Curve
+import Svg.Segment as Segment exposing (Segment(..))
+import Svg.SubPath as SubPath
 import Test exposing (..)
 import Vector2d
 


### PR DESCRIPTION
Hi! This package is very useful, but conflicts with `elm-pages`'s `Path` module. I'm not sure of the best way to namespace this package, but `Svg` felt natural. #5 also seems to point out conflicts 

## Description

rename:

`Curve` => `Svg.Curve`
`Path` => `Svg.Path`
`SubPath` => `Svg.SubPath`
`Segment` => `Svg.Segment`